### PR TITLE
안 쓰는 헤더 정리, 잘못된 URI 수정

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
-import { useLocation, Link } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import {
   Head,
   List,
@@ -11,7 +11,6 @@ import {
 } from "./Header.js";
 import styled from "@emotion/styled";
 import { userContext } from "../../App.jsx";
-import { supabase } from "../../ServerClient.js";
 import { isMobile } from "react-device-detect";
 
 const StyledScrollButton = styled.div((props) => ({

--- a/src/components/Router.jsx
+++ b/src/components/Router.jsx
@@ -26,7 +26,7 @@ function Router() {
         <Route path="/refund/:refundItemID" element={<Refund />}></Route>
         <Route path="/purchaseApprove" element={<PaymentApprove />}></Route>
         <Route path="/paymentSuccess" element={<PaymentSuccess/>}></Route>
-        <Route path="/purchaseFail" element={<PaymentFail/>}></Route>
+        <Route path="/paymentFail" element={<PaymentFail/>}></Route>
       </Routes>
     </BrowserRouter>
   );

--- a/src/pages/ArtWorkDetail/ArtWorkDetail.jsx
+++ b/src/pages/ArtWorkDetail/ArtWorkDetail.jsx
@@ -35,7 +35,6 @@ import {
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { supabase } from "../../ServerClient.js";
 import { userContext } from "../../App";
-import { CircularProgress } from "@mui/material";
 
 function ArtWorkDetail() {
   const nav = useNavigate();

--- a/src/pages/DepartmentDetail/DepartmentDetail.jsx
+++ b/src/pages/DepartmentDetail/DepartmentDetail.jsx
@@ -31,7 +31,7 @@ import departmentInfos from "./DepartmentInfo.json";
 import Header from "../../components/Header/Header.jsx";
 import Footer from "../../components/Footer/Footer.jsx";
 import { supabase } from "../../ServerClient.js";
-import { useQueryClient, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
 // 미술작품 가져오기
 const getArtWorksByDepartment = async (department) => {

--- a/src/pages/Payment/PaymentFail.jsx
+++ b/src/pages/Payment/PaymentFail.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React from "react";
 import Header from "../../components/Header/Header.jsx";
 import {
   Container,
@@ -9,12 +9,9 @@ import {
   GreyButton,
 } from "./PaymentSuccessStyle.js";
 import { RedButton } from "./PaymentFailStyle.js";
-import { userContext } from "../../App.jsx";
 import { useNavigate } from "react-router-dom";
 
 export const PaymentFail = () => {
-  const [user] = useContext(userContext);
-
   const navigate = useNavigate();
 
   const onClickToMain = () => {

--- a/src/pages/Purchased/Purchased.jsx
+++ b/src/pages/Purchased/Purchased.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext } from "react";
 import {
   Container,
   ContentContainer,

--- a/src/pages/Refund/Refund.jsx
+++ b/src/pages/Refund/Refund.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import Header from "../../components/Header/Header.jsx";
 import { Container, ContentContainer, CartText } from "../Cart/CartStyle.js";
 import {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

-[] Feat : 새로운 기능 추가
-[] Bug : 버그 발견
-[] Fix : 버그 수정
-[] Docs : 문서 수정
-[] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
-[o] Refactor : 코드 리펙토링

### 반영 브랜치

refactor -> main

### 변경 사항

결제 실패 시 /purchaseFail 로 리다이렉트되던 코드를 /paymentFail 로 리다이렉트되도록 URI 수정
쭉 읽어보면서 안쓰는데 정의되어있는 헤더들 일부 없앰


### 테스트 결과

딱히 고친 게 없지만 로컬에서는 잘 돌아갑니다


### TODO

LoginComponent.jsx 에서 소셜로그인 후 리다이렉트되는 페이지가 '/#' 가 아닌 원래 위치한 페이지로 리다이렉트되도록 로직 수정 필요

시도해봤지만 잘 안 된 시도:
- 소셜 로그인 전에 localStorage에 redirectPath 저장 + 소셜 로그인 후 해당 페이지로 redirect 및 localStorage 삭제
